### PR TITLE
Update sphero_driver.py

### DIFF
--- a/sphero_driver/src/sphero_driver/sphero_driver.py
+++ b/sphero_driver/src/sphero_driver/sphero_driver.py
@@ -199,7 +199,7 @@ class BTInterface(object):
 
     try:
       self.sock=bluetooth.BluetoothSocket(bluetooth.RFCOMM)
-      self.sock.connect((bdaddr,self.port))
+      self.sock.connect((self.target_address,self.port))
     except bluetooth.btcommon.BluetoothError as error:
       sys.stdout.write(error)
       sys.stdout.flush()


### PR DESCRIPTION
It is no real mistake, but if you took the time to define a target_address member and assign a value to it, better use it afterwards rather than rely on bdaddr which might not be set to the right value any more.
