### PR TITLE
fixed raised error not being caught in class

### DIFF
--- a/sphero_driver/src/sphero_driver/sphero_driver.py
+++ b/sphero_driver/src/sphero_driver/sphero_driver.py
@@ -834,7 +834,8 @@ class Sphero(threading.Thread):
           else:
             print "got a packet that isn't streaming: " + self.data2hexstr(data)
         else:
-          raise RuntimeError("Bad SOF : " + self.data2hexstr(data))
+          sys.stdout.write("Runtime Error - Bad SOF : " + self.data2hexstr(data) + "\nReset data to empty list.\n")
+          data = [] # clear data
       self.raw_data_buf=data
 
   def parse_pwr_notify(self, data, data_length):


### PR DESCRIPTION
Hi, I found out a Runtime Error of Bad SOF is raised in the `recv` function but it is not caught in its caller `run`. Instead of raising the error, I changed the code to write to stdout and clear data instead. With this change, I was able to retrieve data again.   

The other way to do it would be putting `while self.is_connected and not self.shutdown:` in the function `run`. We can then catch the error there and continue.